### PR TITLE
Reject pet for app

### DIFF
--- a/app/views/admin_applications/show.html.erb
+++ b/app/views/admin_applications/show.html.erb
@@ -9,9 +9,12 @@
   <section id="pet-<%= pet_application.pet.id%>">
     <h4>Pet:<%= pet_application.pet.name %></h4>
     <% if pet_application.approved? %>
-    <p>Pet Approved</p>
-    <% else %>
-    <%= button_to "Approve", "/admin/applications/#{@application.id}", method: :patch, params: { pet_application_id: pet_application.id, status: :approved } %>
+      <p>Pet Approved</p>
+    <% elsif pet_application.rejected? %>
+        <p>Pet Rejected</p>
+    <% elsif pet_application %>
+      <%= button_to "Approve", "/admin/applications/#{@application.id}", method: :patch, params: { pet_application_id: pet_application.id, status: :approved } %>
+      <%= button_to "Reject", "/admin/applications/#{@application.id}", method: :patch, params: { pet_application_id: pet_application.id, status: :rejected } %>
     <% end %>
   </section>
 <% end %>

--- a/spec/features/admin_applications/show_spec.rb
+++ b/spec/features/admin_applications/show_spec.rb
@@ -27,6 +27,19 @@ RSpec.describe "Admin Application Show Page" do
     @application = create(:application)
     @application.pets << [@pet_1, @pet_2]
 
+    @application_2 = create(:application)
+    @application_2.pets << [@pet_1]
+
+    # @application_1 = create(:application)
+    # @application_1.pets << [@pet_1]
+    #
+    # @application_2 = create(:application)
+    # @application_2.pets << [@pet_2]
+
+    # @pet_applications_1 = create(:pet_application, application_id: 1, pet_id: 1)
+    # @pet_applications_2 = create(:pet_application, application_id: 1, pet_id: 2)
+
+
     # @shelter_1 = create(:shelter, id: 1)
     # @pet_1 = create(:pet, id: 1, shelter_id: 1, name: "Nikita")
     # @pet_2 = create(:pet, id: 2, shelter_id: 1, name: "Kiko")
@@ -85,6 +98,38 @@ RSpec.describe "Admin Application Show Page" do
       expect(page).to_not have_button("Approve")
       expect(page).to_not have_button("Reject")
       expect(page).to have_content("Pet Rejected")
+    end
+  end
+
+  it "can approve/reject pets on one application without affecting other applications" do
+    # When there are two applications in the system for the same pet
+
+    # When I visit the admin application show page for one of the applications
+    visit "/admin/applications/#{@application.id}"
+
+    within("#pet-#{@pet_1.id}") do
+      expect(page).to have_content("#{@pet_1.name}")
+      expect(page).to have_button("Approve")
+
+      # And I approve or reject the pet for that application
+      click_button("Approve")
+
+      expect(page).to have_content("Pet Approved")
+      expect(page).to_not have_button("Reject")
+      expect(page).to_not have_content("Pet Rejected")
+    end
+
+    # When I visit the other application's admin show page
+    visit "/admin/applications/#{@application_2.id}"
+
+      # Then I do not see that the pet has been accepted or rejected for that application
+      # And instead I see buttons to approve or reject the pet for this specific application
+    within("#pet-#{@pet_1.id}") do
+      expect(page).to have_content("#{@pet_1.name}")
+      expect(page).to_not have_content("Pet Approved")
+      expect(page).to_not have_content("Pet Rejected")
+      expect(page).to have_button("Approve")
+      expect(page).to have_button("Reject")
     end
   end
 end

--- a/spec/features/admin_applications/show_spec.rb
+++ b/spec/features/admin_applications/show_spec.rb
@@ -91,8 +91,8 @@ RSpec.describe "Admin Application Show Page" do
     within "#pet-#{@pet_2.id}" do
       expect(page).to have_content(@pet_2.name)
       expect(page).to have_button("Reject")
-      click_button("Reject")
 
+      click_button("Reject")
 
       expect(current_path).to eq("/admin/applications/#{@application.id}")
       expect(page).to_not have_button("Approve")
@@ -102,16 +102,12 @@ RSpec.describe "Admin Application Show Page" do
   end
 
   it "can approve/reject pets on one application without affecting other applications" do
-    # When there are two applications in the system for the same pet
-
-    # When I visit the admin application show page for one of the applications
     visit "/admin/applications/#{@application.id}"
 
     within("#pet-#{@pet_1.id}") do
       expect(page).to have_content("#{@pet_1.name}")
       expect(page).to have_button("Approve")
 
-      # And I approve or reject the pet for that application
       click_button("Approve")
 
       expect(page).to have_content("Pet Approved")
@@ -119,11 +115,8 @@ RSpec.describe "Admin Application Show Page" do
       expect(page).to_not have_content("Pet Rejected")
     end
 
-    # When I visit the other application's admin show page
     visit "/admin/applications/#{@application_2.id}"
 
-      # Then I do not see that the pet has been accepted or rejected for that application
-      # And instead I see buttons to approve or reject the pet for this specific application
     within("#pet-#{@pet_1.id}") do
       expect(page).to have_content("#{@pet_1.name}")
       expect(page).to_not have_content("Pet Approved")

--- a/spec/features/admin_applications/show_spec.rb
+++ b/spec/features/admin_applications/show_spec.rb
@@ -60,31 +60,31 @@ RSpec.describe "Admin Application Show Page" do
     end
   end
 
-  # it "can reject a pet for adoption" do
-  #   visit "/admin/applications/#{@application.id}"
-  #
-  #   within "#pet-#{@pet_1.id}" do
-  #     expect(page).to have_content(@pet_1.name)
-  #     expect(page).to have_button("Reject")
-  #
-  #     click_button("Reject")
-  #
-  #     expect(current_path).to eq("/admin/applications/#{@application.id}")
-  #     expect(page).to_not have_button("Approve")
-  #     expect(page).to_not have_button("Rejcet")
-  #     expect(page).to have_content("Pet Rejected")
-  #   end
-  #
-  #   within "#pet-#{@pet_2.id}" do
-  #     expect(page).to have_content(@pet_2.name)
-  #     expect(page).to have_button("Reject")
-  #     click_button("Reject")
-  #
-  #
-  #     expect(current_path).to eq("/admin/applications/#{@application.id}")
-  #     expect(page).to_not have_button("Approve")
-  #     expect(page).to_not have_button("Reject")
-  #     expect(page).to have_content("Pet Rejected")
-  #   end
-  # end
+  it "can reject a pet for adoption" do
+    visit "/admin/applications/#{@application.id}"
+
+    within "#pet-#{@pet_1.id}" do
+      expect(page).to have_content(@pet_1.name)
+      expect(page).to have_button("Reject")
+
+      click_button("Reject")
+
+      expect(current_path).to eq("/admin/applications/#{@application.id}")
+      expect(page).to_not have_button("Approve")
+      expect(page).to_not have_button("Rejcet")
+      expect(page).to have_content("Pet Rejected")
+    end
+
+    within "#pet-#{@pet_2.id}" do
+      expect(page).to have_content(@pet_2.name)
+      expect(page).to have_button("Reject")
+      click_button("Reject")
+
+
+      expect(current_path).to eq("/admin/applications/#{@application.id}")
+      expect(page).to_not have_button("Approve")
+      expect(page).to_not have_button("Reject")
+      expect(page).to have_content("Pet Rejected")
+    end
+  end
 end

--- a/spec/features/admin_applications/show_spec.rb
+++ b/spec/features/admin_applications/show_spec.rb
@@ -29,23 +29,6 @@ RSpec.describe "Admin Application Show Page" do
 
     @application_2 = create(:application)
     @application_2.pets << [@pet_1]
-
-    # @application_1 = create(:application)
-    # @application_1.pets << [@pet_1]
-    #
-    # @application_2 = create(:application)
-    # @application_2.pets << [@pet_2]
-
-    # @pet_applications_1 = create(:pet_application, application_id: 1, pet_id: 1)
-    # @pet_applications_2 = create(:pet_application, application_id: 1, pet_id: 2)
-
-
-    # @shelter_1 = create(:shelter, id: 1)
-    # @pet_1 = create(:pet, id: 1, shelter_id: 1, name: "Nikita")
-    # @pet_2 = create(:pet, id: 2, shelter_id: 1, name: "Kiko")
-    # @application = create(:application, id: 1, application_status: "Pending")
-    # @pet_application_1 = create(:pet_application, application_id: 1, pet_id: 1 )
-    # @pet_application_2 = create(:pet_application, application_id: 1, pet_id: 2 )
   end
 
   it "can approve a pet for adoption" do


### PR DESCRIPTION
-Finish up user stories 20 & 19 feature specs with rejecting a pet for adoption and approving/rejecting pets on one application without interfering with another application
- Rearranged logic of if/elsif/else branching in applications show page so the button_to for reject and approve work as expected given each scenario
